### PR TITLE
FIX: Address issue with gfortran compiler and osx.

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 
+if [[ "$target_platform" == osx* ]]; then
+    CMAKE_FLAGS+=" -DCMAKE_OSX_SYSROOT=${CONDA_BUILD_SYSROOT}"
+    CMAKE_FLAGS+=" -DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET}"
+    # Hack around https://github.com/conda-forge/gfortran_osx-64-feedstock/issues/11
+    # Taken from https://github.com/awvwgk/staged-recipes/tree/dftd4/recipes/dftd4
+    # See contents of fake-bin/cc1 for an explanation
+    export PATH="${PATH}:${RECIPE_DIR}/fake-bin"
+fi
+
 mkdir build
 cd build
 

--- a/recipe/fake-bin/cc1
+++ b/recipe/fake-bin/cc1
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+###
+# Taken from https://github.com/awvwgk/staged-recipes/tree/dftd4/recipes/dftd4
+###
+
+# Detecting flags from gfortran which is backed by clang fails with
+#     x86_64-apple-darwin13.4.0-gfortran: error trying to exec 'cc1': execvp: No such file or directory
+# This comes from
+#     https://github.com/mesonbuild/meson/blob/61993f893bbdc2415155e28ee70e6ea806725e64/mesonbuild/environment.py#L668-L671
+# which runs
+#     x86_64-apple-darwin13.4.0-gfortran -E -dM -
+# Looking at the verbose output this is trying to run:
+#     cc1 -E -quiet -v -D__DYNAMIC__ - -fPIC -mmacosx-version-min=10.9 -mtune=generic -dM
+# The -quiet argument must be removed from the arguments as this isn't supported by clang
+# Adding this file to PATH hacks around these issues
+
+# Already reported at: https://github.com/conda-forge/gfortran_osx-64-feedstock/issues/11
+
+ARGS=()
+for var in "$@"; do
+    # Ignore known bad arguments
+    [ "$var" != '-quiet' ] && ARGS+=("$var")
+done
+
+"$CC" "${ARGS[@]}"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "impact-t" %}
 {% set version = "2.0" %}
 
-{% set build = 0 %}
+{% set build = 1 %}
 # ensure mpi is defined (needed for conda-smithy recipe-lint)
 {% set mpi = mpi or 'nompi' %}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,9 +49,11 @@ requirements:
     - {{ compiler('m2w64_fortran') }}        # [win]
     - cmake
   host:
-    - {{ mpi }}  # [mpi != 'nompi']
+    - mpich ==3.3.2  # [mpi == 'mpich']
+    - openmpi  # [mpi == 'openmpi']
   run:
-    - {{ mpi }}  # [mpi != 'nompi']
+    - mpich ==3.3.2  # [mpi == 'mpich']
+    - openmpi  # [mpi == 'openmpi']
 
 test:
   commands:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

IMPACT-T build was failing with mpich as MPI library. The error was:
```

-- Checking whether Fortran compiler supports OSX deployment target flag
-- Checking whether Fortran compiler supports OSX deployment target flag - yes
-- Detecting Fortran compiler ABI info
-- Detecting Fortran compiler ABI info - done
-- Check for working Fortran compiler: $BUILD_PREFIX/bin/x86_64-apple-darwin13.4.0-gfortran - skipped
-- Checking whether $BUILD_PREFIX/bin/x86_64-apple-darwin13.4.0-gfortran supports Fortran 90
-- Checking whether $BUILD_PREFIX/bin/x86_64-apple-darwin13.4.0-gfortran supports Fortran 90 - yes
-- Could NOT find MPI_Fortran (missing: MPI_Fortran_WORKS) 
CMake Error at /Users/runner/miniforge3/conda-bld/impact-t_1611161584027/_build_env/share/cmake-3.19/Modules/FindPackageHandleStandardArgs.cmake:218 (message):
  Could NOT find MPI (missing: MPI_Fortran_FOUND)

      Reason given by package: MPI component 'C' was requested, but language C is not enabled.  MPI component 'CXX' was requested, but language CXX is not enabled.  

Call Stack (most recent call first):
  /Users/runner/miniforge3/conda-bld/impact-t_1611161584027/_build_env/share/cmake-3.19/Modules/FindPackageHandleStandardArgs.cmake:582 (_FPHSA_FAILURE_MESSAGE)
  /Users/runner/miniforge3/conda-bld/impact-t_1611161584027/_build_env/share/cmake-3.19/Modules/FindMPI.cmake:1722 (find_package_handle_standard_args)
  CMakeLists.txt:62 (find_package)
```

After some research it seems to be an error with gfortran that will be addressed via https://github.com/conda-forge/gfortran_osx-64-feedstock/issues/11. For now I am adding the recommended workaround so we can get the packages building properly.


More details on the error here:
https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=266489&view=logs&j=3e4ee4fd-b8bd-564b-3d95-756c41c8c4a3&t=bb57294c-406e-59cf-a1ca-fac22a824fbf&l=1650 
